### PR TITLE
Update copyright for 2024

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "licenseHeader": {
     "licenseType": "apache",
-    "yearRange": "2021-2023",
+    "yearRange": "2023-2024",
     "copyrightHolder": "Buf Technologies, Inc."
   },
   "devDependencies": {

--- a/packages/jest-environment-jsdom-example/jest.config.mjs
+++ b/packages/jest-environment-jsdom-example/jest.config.mjs
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jest-environment-jsdom-example/src/encoding-api.test.ts
+++ b/packages/jest-environment-jsdom-example/src/encoding-api.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jest-environment-jsdom-example/src/encoding-api.ts
+++ b/packages/jest-environment-jsdom-example/src/encoding-api.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jest-environment-jsdom-example/src/typed-arrays.test.ts
+++ b/packages/jest-environment-jsdom-example/src/typed-arrays.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jest-environment-jsdom-example/src/typed-arrays.ts
+++ b/packages/jest-environment-jsdom-example/src/typed-arrays.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This updates the copyright year for 2024.

Note that the previous years were incorrect for this repo since development dates to 2023. The beginning year has been updated to reflect that.